### PR TITLE
fix: viteTags helper

### DIFF
--- a/src/Helpers/vite_helper.php
+++ b/src/Helpers/vite_helper.php
@@ -5,11 +5,16 @@ use Mihatori\CodeigniterVite\Vite;
 /**
  * Get vite entry file or bundled files.
  * 
- * @return array|null
+ * @return string|null
  */
-function viteTags(): ?array
+function viteTags(string $assets): ?string
 {
-    return Vite::tags();
+    if (in_array($assets, ['js', 'css']))
+    {
+        return Vite::tags()[$assets];
+    }
+
+    return null;
 }
 
 /**


### PR DESCRIPTION
improve ` viteTags` function
- returns string instead of array
- in the view file, use `<?= viteTags('js')?>` instead of `<?= viteTags()['js']?>`