### PR TITLE
fixed vite env var typo

### DIFF
--- a/src/Config/env.default
+++ b/src/Config/env.default
@@ -3,7 +3,7 @@
 #--------------------------------------------------------------------
 
 VITE_AUTO_INJECTING=true
-VITE_EXLUDED_ROUTES=''
+VITE_EXCLUDED_ROUTES=''
 VITE_ORIGIN='http://localhost:3479'
 VITE_PORT=3479
 VITE_BUILD_DIR='build'

--- a/src/Vite.php
+++ b/src/Vite.php
@@ -117,7 +117,7 @@ class Vite
 	 */
 	public static function routeIsNotExluded(): bool
 	{
-		$routes = explode(',', env('VITE_EXLUDED_ROUTES'));
+		$routes = explode(',', env('VITE_EXCLUDED_ROUTES'));
 		
 		# remove spaces before and after the route.
 		// foreach($routes as $i => $route) $routes[$i] = ltrim( rtrim($route) );


### PR DESCRIPTION
Applied typo fix, because [ci-svelte-appstarter](https://github.com/firtadokei/ci-svelte-appstarter) was being affected, I was getting an `ErrorException explode(): Passing null to parameter #2 ($string) of type string is deprecated` due to `VITE_EXCLUDED_ROUTES` not existing on the default `env` file upon project creation