### PR TITLE
Fix #31

### DIFF
--- a/src/Vite.php
+++ b/src/Vite.php
@@ -118,6 +118,9 @@ class Vite
 	public static function routeIsNotExluded(): bool
 	{
 		$routes = explode(',', env('VITE_EXCLUDED_ROUTES'));
+
+        # skip checking if VITE_EXCLUDED_ROUTES only contain empty string
+        if(count($routes) === 0 && $routes[0] === "") return true;
 		
 		# remove spaces before and after the route.
 		// foreach($routes as $i => $route) $routes[$i] = ltrim( rtrim($route) );


### PR DESCRIPTION
Previous routeIsNotExluded() make integration with my Codeigniter 4.5.5 not smooth. So, I found that I have to make that method just return true if VITE_EXCLUDED_ROUTES is empty as mentioned on #31 .

Thank you for your attention on this pull request.