### PR TITLE
Fix #31

### DIFF
--- a/src/Vite.php
+++ b/src/Vite.php
@@ -110,18 +110,20 @@ class Vite
         return $result;
     }
 
-	/**
-	 * Check whether the current route is exluded or not.
-	 * 
-	 * @return bool
-	 */
-	public static function routeIsNotExluded(): bool
-	{
-		$routes = explode(',', env('VITE_EXCLUDED_ROUTES'));
-		
-		# remove spaces before and after the route.
-		// foreach($routes as $i => $route) $routes[$i] = ltrim( rtrim($route) );
+    /**
+     * Check whether the current route is exluded or not.
+     * 
+     * @return bool
+     */
+    public static function routeIsNotExluded(): bool
+    {
+        $routes = explode(',', env('VITE_EXCLUDED_ROUTES'));
+        
+        # remove spaces before and after the route.
+        // foreach($routes as $i => $route) $routes[$i] = ltrim( rtrim($route) );
 
-		return !in_array(uri_string(), $routes);
-	}
+        $routes = array_filter($routes, function ($route) { return $route !== ""; });
+
+        return !in_array(uri_string(), $routes);
+    }
 }


### PR DESCRIPTION
When we use explode() for empty string, it will return an empty string inside array. Even when we use explode for string for something like "api,", it will return something like this ["api",""].

This will make codeigniter-vitejs not inject the decorator when we at root URI.

So, I think we should remove that empty string from array ($route).